### PR TITLE
Add Brave support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ ___
 
 This app cannot be published on the AppStore as changing the default browser on iOS is prohibited by Apple.
 
-To install, you either deploy it by yourself to your device from Xcode OR you can use [Cydia Impactor](http://www.cydiaimpactor.com/) to install the `.ipa` directly from [here](https://github.com/trusk89/iOSSwitchr/releases)).
+To install, you either deploy it by yourself to your device from Xcode OR you can use several sideloading services such as [Cydia Impactor](http://www.cydiaimpactor.com/), [AltStore](https://altstore.io), and [AltDeploy](https://github.com/pixelomer/AltDeploy) to install the `.ipa` directly from [here](https://github.com/trusk89/iOSSwitchr/releases)).
 
 ___
 
 ### Known issues:
-1. Brave, Vivaldi, Opera don't work yet
+1. Vivaldi and Opera don't work yet
 
-2. Some URLs (I saw the behavior only in the Messages app and in Notes) are not handled as URLs by the OS, so you need to long press on them and than select `Open Link`
+2. Some URLs (I saw the behavior only in the Messages app and in Notes) are not handled as URLs by the OS, so you need to long press on them and than select `Open Link`.
 
 3. Need to do some propper organising of the classes, as everything is just thrown in there at this point
 ___

--- a/iOSSwitchr/iOSSwitchr/DeepLinkHandler.swift
+++ b/iOSSwitchr/iOSSwitchr/DeepLinkHandler.swift
@@ -25,11 +25,28 @@ class DeepLinkHandler {
                 newURL = unwrappedURL
             }
             
+        case .Brave:
+                   if let unwrappedURL = getBraveURL(from: urlString) {
+                       newURL = unwrappedURL
+                   }
+                   
         default:
             return
         }
        
         UIApplication.shared.open(newURL)
+    }
+    
+    /*
+    *   Brave's URL scheme is the same as Firefox's URL scheme.
+    */
+    private static func getBraveURL(from oldURLString: String) -> URL? {
+        let newString =  "brave://open-url?url=" + oldURLString
+        guard let url = URL(string: newString) else {
+            return nil
+        }
+        
+        return url
     }
     
     private static func getFirefoxURL(from oldURLString: String) -> URL? {
@@ -53,3 +70,4 @@ class DeepLinkHandler {
         return url
     }
 }
+


### PR DESCRIPTION
While Brave for macOS and Windows may be based on Chromium, on iOS it isn't, so it doesn't follow Chrome's URL Scheme, but instead, its URL Scheme is based on Firefox's URL scheme.

This pull request adds:
- Support for Brave browser
- Some more sideloading services to the README since Cydia Impactor doesn't work anymore on macOS Catalina.
