### PR TITLE
Added Brave, Edge and Opera Touch support

### DIFF
--- a/iOSSwitchr/iOSSwitchr.xcodeproj/project.pbxproj
+++ b/iOSSwitchr/iOSSwitchr.xcodeproj/project.pbxproj
@@ -456,10 +456,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_ASSET_PATHS = "\"iOSSwitchr/Preview Content\"";
-				DEVELOPMENT_TEAM = JEW4ZQXUL9;
+				DEVELOPMENT_TEAM = 5G38TVB775;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = iOSSwitchr/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
@@ -468,9 +468,9 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = ro.bartis.iOSSwitchr;
+				PRODUCT_BUNDLE_IDENTIFIER = ro.bartis.iOSSwitchr.jeremymolinaFork;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = Switchr;
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -481,10 +481,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_ASSET_PATHS = "\"iOSSwitchr/Preview Content\"";
-				DEVELOPMENT_TEAM = JEW4ZQXUL9;
+				DEVELOPMENT_TEAM = 5G38TVB775;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = iOSSwitchr/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
@@ -493,9 +493,9 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = ro.bartis.iOSSwitchr;
+				PRODUCT_BUNDLE_IDENTIFIER = ro.bartis.iOSSwitchr.jeremymolinaFork;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = Switchr;
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/iOSSwitchr/iOSSwitchr/Browser.swift
+++ b/iOSSwitchr/iOSSwitchr/Browser.swift
@@ -19,6 +19,7 @@ class Browser {
         case Vivaldi = "vivaldi"
         case Brave = "brave"
         case Opera = "opera"
+        case Edge = "edge"
     }
 
     init(name: String = "none", id: ID = ID.none) {

--- a/iOSSwitchr/iOSSwitchr/DeepLinkHandler.swift
+++ b/iOSSwitchr/iOSSwitchr/DeepLinkHandler.swift
@@ -31,10 +31,14 @@ class DeepLinkHandler {
             }
             
         case .Brave:
-            if let unwrappedURL = getEdgeURL(from: urlString) {
+            if let unwrappedURL = getBraveURL(from: urlString) {
                 newURL = unwrappedURL
             }
-            
+
+        case .Opera:
+            if let unwrappedURL = getOperaURL(from: urlString) {
+                newURL = unwrappedURL
+            }
             
         default:
             return
@@ -79,6 +83,18 @@ class DeepLinkHandler {
     private static func getBraveURL(from oldURLString: String) -> URL? {
         let newString =  "brave://open-url?url=" + oldURLString
         guard let url = URL(string: newString) else {
+            return nil
+        }
+        
+        return url
+    }
+    
+    private static func getOperaURL(from oldURLString: String) -> URL? {
+        let existingScheme = oldURLString.components(separatedBy: ":").first ?? "https"
+        let chromeScheme = existingScheme == "http" ? "touch-http" : "touch-https"
+        let newURLString = oldURLString.replacingOccurrences(of: existingScheme, with: chromeScheme)
+        
+        guard let url = URL(string: newURLString) else {
             return nil
         }
         

--- a/iOSSwitchr/iOSSwitchr/DeepLinkHandler.swift
+++ b/iOSSwitchr/iOSSwitchr/DeepLinkHandler.swift
@@ -24,6 +24,17 @@ class DeepLinkHandler {
             if let unwrappedURL = getChromeURL(from: urlString) {
                 newURL = unwrappedURL
             }
+        
+        case .Edge:
+            if let unwrappedURL = getEdgeURL(from: urlString) {
+                newURL = unwrappedURL
+            }
+            
+        case .Brave:
+            if let unwrappedURL = getEdgeURL(from: urlString) {
+                newURL = unwrappedURL
+            }
+            
             
         default:
             return
@@ -47,6 +58,27 @@ class DeepLinkHandler {
         let newURLString = oldURLString.replacingOccurrences(of: existingScheme, with: chromeScheme)
         
         guard let url = URL(string: newURLString) else {
+            return nil
+        }
+        
+        return url
+    }
+    
+    private static func getEdgeURL(from oldURLString: String) -> URL? {
+        let existingScheme = oldURLString.components(separatedBy: ":").first ?? "https"
+        let chromeScheme = existingScheme == "http" ? "microsoft-edge-http" : "microsoft-edge-https"
+        let newURLString = oldURLString.replacingOccurrences(of: existingScheme, with: chromeScheme)
+        
+        guard let url = URL(string: newURLString) else {
+            return nil
+        }
+        
+        return url
+    }
+    
+    private static func getBraveURL(from oldURLString: String) -> URL? {
+        let newString =  "brave://open-url?url=" + oldURLString
+        guard let url = URL(string: newString) else {
             return nil
         }
         

--- a/iOSSwitchr/iOSSwitchr/Settings.swift
+++ b/iOSSwitchr/iOSSwitchr/Settings.swift
@@ -18,7 +18,8 @@ class Settings: ObservableObject {
                            Browser(name: "Chrome", id: .Chrome),
                            Browser(name: "Vivaldi", id: .Vivaldi),
                            Browser(name: "Brave", id: .Brave),
-                           Browser(name: "Opera", id: .Opera)]
+                           Browser(name: "Opera", id: .Opera),
+                           Browser(name: "Edge", id: .Edge)]
 
     @Published var defaultBrowser: Browser {
         didSet {

--- a/iOSSwitchr/iOSSwitchr/Settings.swift
+++ b/iOSSwitchr/iOSSwitchr/Settings.swift
@@ -15,11 +15,11 @@ class Settings: ObservableObject {
     private let defaultsKey = "DefaultBrowser"
 
     @Published var browsers = [Browser(name: "Firefox", id: .Firefox),
-                           Browser(name: "Chrome", id: .Chrome),
-                           Browser(name: "Vivaldi", id: .Vivaldi),
+                           Browser(name: "Google Chrome", id: .Chrome),
+                           //Browser(name: "Vivaldi", id: .Vivaldi), --removed until is supported and tested
                            Browser(name: "Brave", id: .Brave),
-                           Browser(name: "Opera", id: .Opera),
-                           Browser(name: "Edge", id: .Edge)]
+                           Browser(name: "Opera Touch", id: .Opera),
+                           Browser(name: "Microsoft Edge", id: .Edge)]
 
     @Published var defaultBrowser: Browser {
         didSet {


### PR DESCRIPTION
I added the deep linking for the switcher to work with Brave, Edge and Opera Touch.

I also rename the Browser name to have the actual full name of the app. This doesn’t really affect the functionality but rather the use of the proper public names of each Browser. Feel free to reject those if you want.